### PR TITLE
fix: 缺少依赖 click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
+  "click~=8.3",
   "httpx>=0.25,<1",
   "platformdirs>=3.0,<5",
   "prompt-toolkit>=3.0.36,<4",


### PR DESCRIPTION
pyproject.toml 中缺少依赖 click。
uv.lock 中的版本为 8.3.1，故指定为 `~=8.3`。